### PR TITLE
docs: expand on present information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,11 @@ To add a dataset (see `datasets/yeast-osmotic-stress` as an example of a dataset
 1. Check that your dataset provider isn't already added (some of these datasets act as providers for multiple datasets)
 1. Create a new folder under `datasets/<your-dataset>`
 1. Add a `raw` folder containing your data
-1. Add an attached Snakefile that converts your `raw` data to `processed` data
-1. Add your snakefile to the top-level `run_snakemake.sh` file.
-1. If your dataset is a paper reproduction, add a `reproduction/raw` and `reproduction/processed` folder
+1. Add an attached Snakefile that converts your `raw` data to `processed` data.
+    - Make sure to use `uv` here. See `yeast-osmotic-stress`'s Snakefile for an example.
+1. Add your Snakefile to the top-level `run_snakemake.sh` file.
 1. Add your datasets to the appropiate `configs`
+    - If your dataset has gold standards, make sure to include them here.
 
 ## Adding an algorithm
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,27 @@ snakemake --cores 1 --configfile configs/dmmm.yaml --show-failed-logs -s spras/S
 > [!NOTE]
 > Each one of the dataset categories (at the time of writing, DMMM and PRA) are split into different configuration files.
 > Run each one as you would want.
+
+## Organization
+
+There are four primary folders in this repository:
+
+```
+.
+├── configs
+├── datasets
+├── spras
+└── web
+```
+
+`spras` is the cloned submodule of [SPRAS](https://github.com/reed-compbio/spras), `web` is an
+[astro](https://astro.build/) app which generates the `spras-benchmarking` [output](https://reed-compbio.github.io/spras-benchmarking/),
+`configs` is the YAML file used to talk to SPRAS, and `datasets` contains the raw data.
+
+The workflow runs as so:
+
+1. For every dataset, run its inner `Snakefile`. This is orchestrated through the top-level [`run_snakemake.sh`](./run_snakemake.sh) shell script.
+1. Run each config YAML file in `configs/` with SPRAS.
+1. Build the website in `web` with the generated `output` from all of the SPRAS runs.
+
+For more information on how to add a dataset, see [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,4 @@
+# datasets
+
+Datasets contains both the raw data (straight from the study/database), as well as Python scripts and an associated Snakemake file
+which take all of the raw data and produce SPRAS-compatible data.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,4 @@
+# web
+
+This module is an [Astro](https://astro.build/) project which wraps the output from SPRAS
+into a presentable webpage. See the output: https://reed-compbio.github.io/spras-benchmarking/


### PR DESCRIPTION
Provides the organizational details of the repository, as well as how the current pipeline runs.