### PR TITLE
docs: web build

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,6 @@ The workflow runs as so:
 through the top-level [`run_snakemake.sh`](./run_snakemake.sh) shell script.
 1. Run each config YAML file in `configs/` with SPRAS.
 1. Build the website in `web` with the generated `output` from all of the SPRAS runs, and deploy it on [GitHub Pages](https://pages.github.com/).
+To see how to build the website, go to its [README](./web/README.md).
 
 For more information on how to add a dataset, see [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/web/README.md
+++ b/web/README.md
@@ -2,3 +2,25 @@
 
 This module is an [Astro](https://astro.build/) project which wraps the output from SPRAS
 into a presentable webpage. See the output: https://reed-compbio.github.io/spras-benchmarking/
+
+## Building
+
+To build this, you need [`pnpm`](https://pnpm.io/). It is recommended to use a node version manager
+([nvm](https://github.com/nvm-sh/nvm) for mac/linux, [nvm-windows](https://github.com/coreybutler/nvm-windows) for windows),
+to install `nodejs` and `npm` (at the time of writing, this would be node `v22`), and use `npm` to install `pnpm`:
+
+```sh
+npm install --global pnpm
+```
+
+After this, you can install the dependencies (make sure your current working directory is `web`):
+
+```sh
+pnpm install
+```
+
+Then, assuming your data is in `public/data`, build the website:
+
+```sh
+pnpm run build
+```


### PR DESCRIPTION
Adds some documentation for how to install the necessary dependencies for `web`, and how to build it given SPRAS output.