### PR TITLE
fix: force cwd, err catching in script

### DIFF
--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -1,9 +1,22 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 # Snakemake does not support importing and orchestrating multiple Snakefiles
 # in a way that respects the origin directory.
 # Instead, we provide a shell script.
+# We use some error-catching boilerplate from https://sharats.me/posts/shell-script-best-practices/.
 
-uv tool run snakemake --cores 1 -d datasets/rn-muscle-skeletal -s datasets/rn-muscle-skeletal/Snakefile
-uv tool run snakemake --cores 1 -d datasets/yeast-osmotic-stress -s datasets/yeast-osmotic-stress/Snakefile
-uv tool run snakemake --cores 1 -d datasets/synthetic-data -s datasets/synthetic-data/Snakefile
-uv tool run snakemake --cores 1 -d datasets/hiv -s datasets/hiv/Snakefile
+# Strict settings
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+# Forcibly use the current CWD
+cd "$(dirname "$0")"
+
+main() {
+    uv tool run snakemake --cores 1 -d datasets/yeast-osmotic-stress -s datasets/yeast-osmotic-stress/Snakefile
+    uv tool run snakemake --cores 1 -d datasets/hiv -s datasets/hiv/Snakefile
+}
+
+main "$@"

--- a/run_snakemake.sh
+++ b/run_snakemake.sh
@@ -7,9 +7,7 @@
 
 # Strict settings
 set -o errexit
-set -o pipefail
 set -o nounset
-
 
 # Forcibly use the current CWD
 cd "$(dirname "$0")"


### PR DESCRIPTION
If one snakemake file fails, the entire script should. Also fixes cwd.